### PR TITLE
Add postman

### DIFF
--- a/nix/nix-darwin/system/default.nix
+++ b/nix/nix-darwin/system/default.nix
@@ -51,6 +51,9 @@
           {
             app = "${packages.pkgs.zotero}/Applications/Zotero.app";
           }
+          {
+            app = "/Applications/Postman.app";
+          }
         ] ++ extra-dock-persistent-apps;
       };
 

--- a/nix/programs/default-darwin.nix
+++ b/nix/programs/default-darwin.nix
@@ -39,6 +39,7 @@ let
     (import ./skimpdf { inherit packages; })
     (import ./zotero { inherit packages; })
     (import ./sequel-ace { inherit packages; })
+    (import ./postman { inherit packages; })
   ];
 in
 {

--- a/nix/programs/postman/default.nix
+++ b/nix/programs/postman/default.nix
@@ -1,0 +1,12 @@
+{
+  ...
+}:
+{
+  nixDarwinModules = [
+    {
+      homebrew.casks = [
+        "postman"
+      ];
+    }
+  ];
+}


### PR DESCRIPTION
This pull request adds support for the Postman application to the Nix Darwin configuration. The main changes involve making Postman available as a managed application, both through Homebrew and as a persistent app in the Dock.

**Postman integration:**

* Added a new module `nix/programs/postman/default.nix` to install Postman via Homebrew cask.
* Registered the new Postman module in `nix/programs/default-darwin.nix` to ensure it is included in the system's program imports.

**Dock configuration:**

* Added Postman to the list of persistent Dock applications in `nix/nix-darwin/system/default.nix`, so it appears in the Dock by default.