### PR TITLE
Allow some tools

### DIFF
--- a/nix/programs/claude-code/settings.json
+++ b/nix/programs/claude-code/settings.json
@@ -50,6 +50,7 @@
       "Bash(sort:*)",
       "Bash(tail:*)",
       "Bash(tar:*)",
+      "Bash(test:*)",
       "Bash(touch:*)",
       "Bash(tree:*)",
       "Bash(true)",


### PR DESCRIPTION
This pull request makes a small update to the `nix/programs/claude-code/settings.json` configuration file, adding support for an additional Bash command.

* Added `"Bash(test:*)"` to the list of supported Bash commands in `settings.json`.