### PR TITLE
Add new mac

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
     }:
     let
       current-system = (if builtins ? currentSystem then builtins.currentSystem else "aarch64-linux");
-      macbook-air-2nd = import ./nix/hosts/macbook-air-2nd {
+      nishiyamanomacbook-air = import ./nix/hosts/nishiyamanomacbook-air {
         inherit inputs;
       };
       opl2401-013 = import ./nix/hosts/opl2401-013 {
@@ -71,7 +71,7 @@
       systems = [
         devcontainer.system
         devcontainer-claude.system
-        macbook-air-2nd.system
+        nishiyamanomacbook-air.system
         opl2401-013.system
         desktop-62r22ok.system
       ];
@@ -82,7 +82,7 @@
 
       flake = {
         darwinConfigurations = {
-          ${macbook-air-2nd.hostname} = macbook-air-2nd.darwinConfiguration;
+          ${nishiyamanomacbook-air.hostname} = nishiyamanomacbook-air.darwinConfiguration;
           ${opl2401-013.hostname} = opl2401-013.darwinConfiguration;
         };
 

--- a/nix/hosts/nishiyamanomacbook-air/default.nix
+++ b/nix/hosts/nishiyamanomacbook-air/default.nix
@@ -4,9 +4,9 @@
 let
   nix-root-dir = ../..;
 
-  hostname = "macbook-air-2nd";
+  hostname = "nishiyamanomacbook-air";
   system = "aarch64-darwin";
-  username = "workuser";
+  username = "mizunashi";
   homedir = "/Users/${username}";
 
   packages = import "${nix-root-dir}/packages" {

--- a/nix/nix-darwin/system/default.nix
+++ b/nix/nix-darwin/system/default.nix
@@ -51,9 +51,6 @@
           {
             app = "${packages.pkgs.zotero}/Applications/Zotero.app";
           }
-          {
-            app = "/Applications/Postman.app";
-          }
         ]
         ++ extra-dock-persistent-apps;
       };

--- a/nix/programs/ssh/conf.d/colima.conf
+++ b/nix/programs/ssh/conf.d/colima.conf
@@ -1,0 +1,1 @@
+Include ~/.colima/ssh_config

--- a/nix/programs/ssh/default.nix
+++ b/nix/programs/ssh/default.nix
@@ -14,11 +14,14 @@
       };
 
       home.file = {
+        ".ssh/ppkey/.keep" = {
+          text = "";
+        };
         ".ssh/conf.d/common-hosts.conf" = {
           text = builtins.readFile ./conf.d/common-hosts.conf;
         };
-        ".ssh/ppkey/.keep" = {
-          text = "";
+        ".ssh/conf.d/colima.conf" = {
+          text = builtins.readFile ./conf.d/colima.conf;
         };
       };
     }

--- a/tasks/post-darwin-setup/setup.sh
+++ b/tasks/post-darwin-setup/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "${TRACE:-}" ] && set -x
+
+EXPECT_SHELL="$(grep /fish /etc/shells | tail -1)"
+
+if [ "$SHELL" != "$EXPECT_SHELL" ]; then
+	chsh -s "$EXPECT_SHELL"
+fi


### PR DESCRIPTION
This pull request primarily renames the `macbook-air-2nd` host configuration to `nishiyamanomacbook-air` across the codebase and updates related settings and scripts to reflect this change. It also introduces improvements to the setup scripts for better maintainability and adds new configuration for SSH and post-setup tasks on Darwin systems.

**Host configuration renaming and updates:**

* Renamed all references and configuration files from `macbook-air-2nd` to `nishiyamanomacbook-air` in `flake.nix` and moved/updated the corresponding host file, including hostname and username changes (`workuser` → `mizunashi`). [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L54-R54) [[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L74-R74) [[3]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L85-R85) [[4]](diffhunk://#diff-8a9a14aa13a0acc8b392836ff9c39bc94b9d9f9dfc8acb83a1b68efae631c7aeL7-R9)

**Setup script improvements:**

* Refactored `setup.sh` to use new variables (`SETUP_TYPE`, `USE_HOMEBREW`) for clearer platform detection and script flow, and updated the logic for running Homebrew and post-setup scripts.
* Added a new `tasks/post-darwin-setup/setup.sh` script to automatically switch the shell to fish after Darwin setup completes.

**SSH configuration enhancements:**

* Added inclusion of Colima SSH config (`Include ~/.colima/ssh_config`) and ensured it is installed as part of the home file setup. [[1]](diffhunk://#diff-154ffc43a4b55b5dcc38e587664f64a42a334d68185b5c701226719ac9d76944R1) [[2]](diffhunk://#diff-25d1f013f7395563e66c1b7505dd38fa71c82679daef698ce9763dd11c6e1de3R17-R24)

**Other configuration changes:**

* Removed `Postman.app` from the list of persistent dock apps in the Darwin system configuration.