### PR TITLE
Add codex

### DIFF
--- a/nix/node2nix/node-packages.json
+++ b/nix/node2nix/node-packages.json
@@ -1,7 +1,6 @@
 [
   {
     "@anthropic-ai/claude-code": "",
-    "@openai/codex": "",
-    "ccusage": ""
+    "@openai/codex": ""
   }
 ]

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -31,6 +31,6 @@ in
 
   node-packages = node2nix-pkgs // {
     "@anthropic-ai/claude-code" = node2nix-pkgs."@anthropic-ai/claude-code-";
-    "ccusage" = node2nix-pkgs."ccusage-";
+    "@openai/codex" = node2nix-pkgs."@openai/codex-";
   };
 }

--- a/nix/programs/claude-code/default.nix
+++ b/nix/programs/claude-code/default.nix
@@ -7,7 +7,6 @@
     {
       home.packages = [
         packages.node-packages."@anthropic-ai/claude-code"
-        packages.node-packages."ccusage"
       ];
 
       home.file = {

--- a/nix/programs/codex/default.nix
+++ b/nix/programs/codex/default.nix
@@ -1,0 +1,13 @@
+{
+  packages,
+  ...
+}:
+{
+  homeManagerImports = [
+    {
+      home.packages = [
+        packages.node-packages."@openai/codex"
+      ];
+    }
+  ];
+}

--- a/nix/programs/default-common.nix
+++ b/nix/programs/default-common.nix
@@ -30,6 +30,7 @@ let
     (import ./claude-code { inherit packages; })
     (import ./docker-client { inherit packages; })
     (import ./gemini-cli { inherit packages; })
+    (import ./codex { inherit packages; })
   ];
 in
 {


### PR DESCRIPTION
This pull request updates the Nix package configuration to add support for the `@openai/codex` package and removes the deprecated `ccusage` package. The changes ensure that `@openai/codex` is properly imported, available for use, and integrated into the relevant program modules.

**Package management updates:**

* Added `@openai/codex` to the `node-packages.json` file and removed `ccusage`, ensuring only currently supported packages are listed.
* Updated the `default.nix` package mapping to include `@openai/codex` and remove `ccusage`, so the new package is available in the environment.

**Program module integration:**

* Removed `ccusage` from the `claude-code` program dependencies to reflect its deprecation.
* Added a new `codex` program module that imports `@openai/codex` as a dependency, making it available for use via Home Manager.
* Included the new `codex` program in the common program imports, ensuring it is part of the default configuration.