### PR TITLE
Update claude-code allowed

### DIFF
--- a/nix/programs/claude-code/settings.json
+++ b/nix/programs/claude-code/settings.json
@@ -115,6 +115,7 @@
       "mcp__playwright__browser_file_upload",
       "mcp__playwright__browser_fill_form",
       "mcp__playwright__browser_handle_dialog",
+      "mcp__playwright__browser_hover",
       "mcp__playwright__browser_install",
       "mcp__playwright__browser_network_requests",
       "mcp__playwright__browser_take_screenshot",


### PR DESCRIPTION
This pull request makes a minor update to the Playwright skills configuration by adding support for browser hover actions.

* Added `"mcp__playwright__browser_hover"` to the list of enabled Playwright skills in `nix/programs/claude-code/settings.json`.