### PR TITLE
Update cc settings

### DIFF
--- a/nix/programs/claude-code/settings.json
+++ b/nix/programs/claude-code/settings.json
@@ -6,6 +6,9 @@
     "DISABLE_AUTOUPDATER": "1"
   },
   "permissions": {
+    "additionalDirectories": [
+      "/tmp/"
+    ],
     "allow": [
       "Bash(basename:*)",
       "Bash(cat:*)",
@@ -49,6 +52,7 @@
       "Bash(npm uninstall:*)",
       "Bash(npx eslint:*)",
       "Bash(od:*)",
+      "Bash(ollama pull:*)",
       "Bash(pwd:*)",
       "Bash(pre-commit run:*)",
       "Bash(rg:*)",


### PR DESCRIPTION
This pull request updates the `nix/programs/claude-code/settings.json` file to enhance file access permissions and expand the set of allowed Bash commands. The most important changes are grouped below:

Permissions updates:

* Added `/tmp/` to the list of `additionalDirectories`, allowing the program to access files in the `/tmp/` directory.

Allowed commands expansion:

* Added `Bash(ollama pull:*)` to the list of permitted Bash commands, enabling the execution of `ollama pull` commands.