### PR TITLE
Remove phpstorm

### DIFF
--- a/nix/hosts/nishiyamanomacbook-pro/default.nix
+++ b/nix/hosts/nishiyamanomacbook-pro/default.nix
@@ -36,15 +36,11 @@ in
               app = "/Applications/Slack.app";
             }
             {
-              app = "/Applications/PhpStorm.app";
-            }
-            {
               app = "/Applications/Figma.app";
             }
           ];
 
           extra-programs = [
-            (import "${nix-root-dir}/programs/phpstorm" { inherit packages; })
             (import "${nix-root-dir}/programs/slack" { inherit packages; })
             (import "${nix-root-dir}/programs/figma" { inherit packages; })
             (import "${nix-root-dir}/programs/docker-desktop" { inherit packages; })


### PR DESCRIPTION
This pull request makes a small update to the `nix/hosts/nishiyamanomacbook-pro/default.nix` configuration by removing references to PhpStorm. Both the application entry and the extra program import for PhpStorm have been deleted. 

- Removed the `/Applications/PhpStorm.app` entry from the list of managed applications.
- Removed the import of the PhpStorm program from the `extra-programs` list.