### PR TITLE
Enable CC OTEL

### DIFF
--- a/nix/programs/claude-code/settings.json
+++ b/nix/programs/claude-code/settings.json
@@ -3,7 +3,11 @@
     "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1",
     "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
     "CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL": "1",
-    "DISABLE_AUTOUPDATER": "1"
+    "DISABLE_AUTOUPDATER": "1",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_METRICS_EXPORTER": "otlp"
   },
   "permissions": {
     "additionalDirectories": [


### PR DESCRIPTION
This pull request adds configuration for OpenTelemetry (OTel) exporters to the `nix/programs/claude-code/settings.json` file, enabling telemetry data to be sent to a local OTel collector. No other changes are included.

Telemetry and observability configuration:

* Added `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_LOGS_EXPORTER`, and `OTEL_METRICS_EXPORTER` environment variables to enable exporting logs and metrics to a local OTel collector using the OTLP gRPC protocol.