### PR TITLE
Add cc allowed

### DIFF
--- a/nix/programs/claude-code/settings.json
+++ b/nix/programs/claude-code/settings.json
@@ -45,6 +45,7 @@
       "Bash(head:*)",
       "Bash(jq:*)",
       "Bash(ls:*)",
+      "Bash(magick:*)",
       "Bash(make)",
       "Bash(mkdir:*)",
       "Bash(mv:*)",


### PR DESCRIPTION
This pull request makes a small update to the `nix/programs/claude-code/settings.json` configuration file, adding support for a new Bash command.

* Added `"Bash(magick:*)"` to the list of supported Bash commands, enabling handling of ImageMagick (`magick`) commands.