### PR TITLE
Support aws-sam-cli

### DIFF
--- a/nix/hosts/nishiyamanomacbook-pro/default.nix
+++ b/nix/hosts/nishiyamanomacbook-pro/default.nix
@@ -55,10 +55,6 @@ in
         nixDarwinModules.modules
         ++ [
           {
-            homebrew.brews = [
-              "git-flow-avh"
-            ];
-
             home-manager.users.${username} = {
               programs.git.settings = {
                 user.name = "Nishiyama Shun";

--- a/nix/programs/awscli/default.nix
+++ b/nix/programs/awscli/default.nix
@@ -10,6 +10,7 @@
       };
 
       home.packages = [
+        packages.pkgs.aws-sam-cli
         packages.pkgs.ssm-session-manager-plugin
       ];
     }

--- a/nix/programs/claude-code/settings.json
+++ b/nix/programs/claude-code/settings.json
@@ -52,6 +52,7 @@
       "Bash(make)",
       "Bash(mkdir:*)",
       "Bash(mv:*)",
+      "Bash(nkf:*)",
       "Bash(npm audit fix)",
       "Bash(npm ci)",
       "Bash(npm info:*)",

--- a/nix/programs/docker-desktop/default.nix
+++ b/nix/programs/docker-desktop/default.nix
@@ -5,7 +5,7 @@
   nixDarwinModules = [
     {
       homebrew.casks = [
-        "docker"
+        "docker-desktop"
       ];
     }
   ];


### PR DESCRIPTION
This pull request makes several updates to the Nix configuration, focusing on improving package management and tool availability. The most notable changes include replacing the Docker package, adding new CLI tools, and updating command settings.

**Package management and tool updates:**

* Replaced the Homebrew cask `docker` with `docker-desktop` in the `nix/programs/docker-desktop/default.nix` configuration to ensure the correct Docker application is installed.
* Removed the installation of the `git-flow-avh` Homebrew formula from the `nix/hosts/nishiyamanomacbook-pro/default.nix` host configuration.
* Added `aws-sam-cli` to the list of installed packages in the AWS CLI program configuration (`nix/programs/awscli/default.nix`), improving AWS development tooling.

**Command and settings enhancements:**

* Added support for the `nkf` command in the Claude Code settings (`nix/programs/claude-code/settings.json`), expanding the set of allowed Bash commands.