### PR TITLE
Add gh pr diff to allowed commands

### DIFF
--- a/nix/programs/claude-code/settings.json
+++ b/nix/programs/claude-code/settings.json
@@ -30,6 +30,7 @@
       "Bash(gemini:*)",
       "Bash(gh label list:*)",
       "Bash(gh pr checks:*)",
+      "Bash(gh pr diff:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr view:*)",
       "Bash(gh run download:*)",


### PR DESCRIPTION
## 目的

Claude Code で `gh pr diff` コマンドを実行できるようにする。

## 変更概要

- `nix/programs/claude-code/settings.json` に `gh pr diff` コマンドを許可リストに追加

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)