### PR TITLE
Raycast アプリのパッケージ参照を修正

### DIFF
--- a/nix/nix-darwin/system/default.nix
+++ b/nix/nix-darwin/system/default.nix
@@ -59,7 +59,7 @@
             app = "${packages.pkgs.dbeaver-bin}/Applications/dbeaver.app";
           }
           {
-            app = "${packages.pkgs.dbeaver-bin}/Applications/Raycast.app";
+            app = "${packages.pkgs.raycast}/Applications/Raycast.app";
           }
         ]
         ++ extra-dock-persistent-apps;


### PR DESCRIPTION
## 目的

Dock に追加する Raycast アプリのパッケージ参照が誤っていたため修正する。

## 変更概要

- `nix/nix-darwin/system/default.nix` で Raycast.app のパッケージ参照を `packages.pkgs.dbeaver-bin` から `packages.pkgs.raycast` に修正

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)