### PR TITLE
Claude Desktop を macOS デフォルトプログラムに追加

### DIFF
--- a/nix/programs/default-darwin.nix
+++ b/nix/programs/default-darwin.nix
@@ -41,6 +41,7 @@ let
     (import ./zotero { inherit packages; })
     (import ./postman { inherit packages; })
     (import ./raycast { inherit packages; })
+    (import ./claude-desktop { inherit packages; })
     (import ./xcode { inherit packages; })
   ];
 in


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

macOS 環境で Claude Desktop アプリケーションをデフォルトプログラムとして利用できるようにする。

## 変更概要

- `nix/programs/default-darwin.nix` に `claude-desktop` モジュールのインポートを追加

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)