### PR TITLE
Ollama の導入

### DIFF
--- a/nix/programs/default-darwin.nix
+++ b/nix/programs/default-darwin.nix
@@ -43,6 +43,7 @@ let
     (import ./raycast { inherit packages; })
     (import ./claude-desktop { inherit packages; })
     (import ./xcode { inherit packages; })
+    (import ./ollama { inherit packages; })
   ];
 in
 {

--- a/nix/programs/ollama/default.nix
+++ b/nix/programs/ollama/default.nix
@@ -1,0 +1,12 @@
+{
+  ...
+}:
+{
+  homeManagerImports = [
+    {
+      services.ollama = {
+        enable = true;
+      };
+    }
+  ];
+}


### PR DESCRIPTION
## 目的

ローカル環境で LLM を実行するために Ollama を導入します。

## 変更概要

- `nix/programs/ollama/default.nix` を新規作成し、home-manager の `services.ollama` を有効化
- `nix/programs/default-darwin.nix` に Ollama モジュールのインポートを追加

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)