### PR TITLE
gh repo view コマンドの許可を追加

### DIFF
--- a/nix/programs/claude-code/settings.json
+++ b/nix/programs/claude-code/settings.json
@@ -40,6 +40,7 @@
       "Bash(gh pr list:*)",
       "Bash(gh pr view:*)",
       "Bash(gh release list:*)",
+      "Bash(gh repo view:*)",
       "Bash(gh run download:*)",
       "Bash(gh run list:*)",
       "Bash(gh run view:*)",


### PR DESCRIPTION
## 目的

Claude Code の設定で `gh repo view` コマンドの実行を許可するため。

## 変更概要

- `nix/programs/claude-code/settings.json` の許可リストに `Bash(gh repo view:*)` を追加

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)