### PR TITLE
Claude Code settings に do echo コマンドの許可を追加

### DIFF
--- a/nix/programs/claude-code/settings.json
+++ b/nix/programs/claude-code/settings.json
@@ -29,6 +29,7 @@
       "Bash(diff:*)",
       "Bash(done:*)",
       "Bash(do sed:*)",
+      "Bash(do echo:*)",
       "Bash(echo:*)",
       "Bash(find:*)",
       "Bash(file:*)",


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

Claude Code の許可設定で `Bash(do echo:*)` パターンが不足していたため追加する。

## 変更概要

- `nix/programs/claude-code/settings.json` の許可リストに `Bash(do echo:*)` を追加

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)