### PR TITLE
WebFetch の許可ドメインに docs.github.com と docs.npmjs.com を追加

### DIFF
--- a/nix/programs/claude-code/settings.json
+++ b/nix/programs/claude-code/settings.json
@@ -141,6 +141,8 @@
       "WebFetch(domain:api.github.com)",
       "WebFetch(domain:developers.notion.com)",
       "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:docs.github.com)",
+      "WebFetch(domain:docs.npmjs.com)",
       "WebFetch(domain:docs.slack.dev)",
       "WebFetch(domain:gist.github.com)",
       "WebFetch(domain:gist.githubusercontent.com)",


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

Claude Code の WebFetch ツールで GitHub ドキュメントと npm ドキュメントを参照できるようにする。

## 変更概要

- `docs.github.com` を WebFetch 許可ドメインに追加
- `docs.npmjs.com` を WebFetch 許可ドメインに追加

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)