### PR TITLE
Claude Code の許可設定に git reset --soft を追加

### DIFF
--- a/nix/programs/claude-code/settings.json
+++ b/nix/programs/claude-code/settings.json
@@ -59,6 +59,7 @@
       "Bash(git mv:*)",
       "Bash(git rebase --continue)",
       "Bash(git remote get-url:*)",
+      "Bash(git reset --soft:*)",
       "Bash(git rev-parse:*)",
       "Bash(git show:*)",
       "Bash(git submodule status:*)",


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

Claude Code でコミットの取り消し（soft reset）操作を行えるようにするため、許可設定を追加する。

## 変更概要

- `Bash(git reset --soft:*)` の許可を追加（作業ツリーを保持したままコミットを戻す操作を許可）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)