### PR TITLE
cc-voice-reporter を 2.1.0 に更新し Notification hooks を追加

### DIFF
--- a/nix/node2nix/node-packages.nix
+++ b/nix/node2nix/node-packages.nix
@@ -90,10 +90,10 @@ in
   "@mizunashi_mana/cc-voice-reporter-" = nodeEnv.buildNodePackage {
     name = "_at_mizunashi_mana_slash_cc-voice-reporter";
     packageName = "@mizunashi_mana/cc-voice-reporter";
-    version = "2.0.0";
+    version = "2.1.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@mizunashi_mana/cc-voice-reporter/-/cc-voice-reporter-2.0.0.tgz";
-      sha512 = "xKz2n85t+iN0EFuhw2fFqKZNV/Ww8Vic4wBDk/XX7gfHjb6RAblYi3Lgt9fbIyq9HYIvvSJeidtVaYI2Nro8jA==";
+      url = "https://registry.npmjs.org/@mizunashi_mana/cc-voice-reporter/-/cc-voice-reporter-2.1.0.tgz";
+      sha512 = "BLuerZfXjFt5p/GYUukpOr9c9WuE0BayVW73FbrWQtW5RqbuRXO/+3SzhJL+666iaBJkLCvv6+x1Nd+sRR6ceQ==";
     };
     dependencies = [
       sources."chokidar-5.0.0"

--- a/nix/programs/claude-code/settings.json
+++ b/nix/programs/claude-code/settings.json
@@ -13,6 +13,16 @@
     "OTEL_METRICS_EXPORTER": "otlp"
   },
   "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "command": "cc-voice-reporter hook-receiver",
+            "type": "command"
+          }
+        ]
+      }
+    ],
     "PermissionRequest": [
       {
         "hooks": [


### PR DESCRIPTION
## 目的

cc-voice-reporter パッケージを最新版に更新し、Notification イベントの hooks 設定を追加する。

## 変更概要

- cc-voice-reporter を 2.0.0 から 2.1.0 にアップデート
- claude-code の settings.json に Notification hooks を追加（cc-voice-reporter hook-receiver）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)