### PR TITLE
node2nix パッケージを再生成

### DIFF
--- a/nix/node2nix/node-packages.nix
+++ b/nix/node2nix/node-packages.nix
@@ -90,10 +90,10 @@ in
   "@mizunashi_mana/cc-voice-reporter-" = nodeEnv.buildNodePackage {
     name = "_at_mizunashi_mana_slash_cc-voice-reporter";
     packageName = "@mizunashi_mana/cc-voice-reporter";
-    version = "2.1.0";
+    version = "2.2.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@mizunashi_mana/cc-voice-reporter/-/cc-voice-reporter-2.1.0.tgz";
-      sha512 = "BLuerZfXjFt5p/GYUukpOr9c9WuE0BayVW73FbrWQtW5RqbuRXO/+3SzhJL+666iaBJkLCvv6+x1Nd+sRR6ceQ==";
+      url = "https://registry.npmjs.org/@mizunashi_mana/cc-voice-reporter/-/cc-voice-reporter-2.2.0.tgz";
+      sha512 = "TkAw5JlEy4bDyHyIrpGLictS45xFkj0wNfcLN9uubFF5XwT73MPUDwY/37DsZLGNRx5rj3bMeZbvjz1yK7qUKw==";
     };
     dependencies = [
       sources."chokidar-5.0.0"


### PR DESCRIPTION
## 目的

node2nix で管理しているパッケージ定義を最新の状態に再生成する。

## 変更概要

- `nix/node2nix/default.nix` のパッケージ定義を更新
- `nix/node2nix/node-env.nix` を再生成（nixfmt によるフォーマット適用）
- `nix/node2nix/node-packages.nix` のパッケージ定義を更新

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)