### PR TITLE
github-mcp-server を programs モジュールとして追加

### DIFF
--- a/.ai-agent/tasks/20260415-add-github-mcp-server/README.md
+++ b/.ai-agent/tasks/20260415-add-github-mcp-server/README.md
@@ -1,0 +1,24 @@
+# github-mcp-server を programs として追加
+
+## 目的・ゴール
+
+nixpkgs unstable の `github-mcp-server` パッケージを programs モジュールとして追加し、darwin 環境で常にインストールされるようにする。
+
+## 実装方針
+
+1. `nix/programs/github-mcp-server/default.nix` を新規作成
+   - `home.packages` で `packages.pkgs.github-mcp-server` をインストール
+2. `nix/programs/default-darwin.nix` に import を追加
+
+## 完了条件
+
+- [x] `nix/programs/github-mcp-server/default.nix` が存在する
+- [x] `nix/programs/default-darwin.nix` に github-mcp-server の import がある
+- [x] `devenv shell lint-all` が通る
+- [ ] PR を作成
+
+## 作業ログ
+
+- `nix/programs/github-mcp-server/default.nix` を作成（`home.packages` で `packages.pkgs.github-mcp-server` をインストール）
+- `nix/programs/default-darwin.nix` に import を追加
+- `devenv shell lint-all` 通過確認済み

--- a/nix/programs/default-darwin.nix
+++ b/nix/programs/default-darwin.nix
@@ -50,6 +50,7 @@ let
     (import ./mcp-html-artifacts-preview { inherit packages; })
     (import ./playwright-mcp { inherit packages; })
     (import ./helm { inherit packages; })
+    (import ./github-mcp-server { inherit packages; })
   ];
 in
 {

--- a/nix/programs/github-mcp-server/default.nix
+++ b/nix/programs/github-mcp-server/default.nix
@@ -1,0 +1,13 @@
+{
+  packages,
+  ...
+}:
+{
+  homeManagerImports = [
+    {
+      home.packages = [
+        packages.pkgs.github-mcp-server
+      ];
+    }
+  ];
+}


### PR DESCRIPTION
## 目的

Claude Code で GitHub MCP Server を利用するため、`github-mcp-server` を darwin 環境にインストールできるようにする。

## 変更概要

- `nix/programs/github-mcp-server/default.nix` を新規作成（nixpkgs unstable の `github-mcp-server` を `home.packages` でインストール）
- `nix/programs/default-darwin.nix` に import を追加し、darwin 環境で常にインストールされるように設定

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)