### PR TITLE
claude-code の defaultMode を auto に変更し権限を追加

### DIFF
--- a/nix/hosts/nishiyamanomacbook-pro/default.nix
+++ b/nix/hosts/nishiyamanomacbook-pro/default.nix
@@ -61,13 +61,7 @@ in
               home-manager.users.${username} = {
                 programs.git.settings = {
                   user.name = "Nishiyama Shun";
-                  user.email = "nishiyama_shun@openlogi.com";
-                };
-
-                programs.claude-code.settings = {
-                  permissions = {
-                    defaultMode = lib.mkForce "auto";
-                  };
+                  user.email = "shun.nishiyama@ascendlogi.co.jp";
                 };
               };
             }

--- a/nix/programs/claude-code/default.nix
+++ b/nix/programs/claude-code/default.nix
@@ -159,7 +159,11 @@
                 "Bash(nix flake check)"
                 "Bash(nix flake metadata:*)"
                 "Bash(nix flake show)"
+                "Bash(nix hash:*)"
                 "Bash(nix log:*)"
+                "Bash(nix-prefetch-github:*)"
+                "Bash(nix-prefetch-url:*)"
+                "Bash(nix search:*)"
                 "Bash(nkf:*)"
                 "Bash(node --version)"
                 "Bash(npm audit)"
@@ -303,6 +307,7 @@
                 "WebFetch(domain:gist.githubusercontent.com)"
                 "WebFetch(domain:github.com)"
                 "WebFetch(domain:global.moneyforward-dev.jp)"
+                "WebFetch(domain:graphite.com)"
                 "WebFetch(domain:itunes.apple.com)"
                 "WebFetch(domain:localhost)"
                 "WebFetch(domain:mizunashi-mana.github.io)"
@@ -317,6 +322,7 @@
                 "WebFetch(domain:pypi.org)"
                 "WebFetch(domain:raw.githubusercontent.com)"
                 "WebFetch(domain:research.google)"
+                "WebFetch(domain:registry.npmjs.org)"
                 "WebFetch(domain:signoz.io)"
                 "WebFetch(domain:socket.dev)"
                 "WebFetch(domain:stackoverflow.com)"
@@ -451,7 +457,7 @@
                 "mcp__html-artifacts-preview__add_scripts"
                 "mcp__html-artifacts-preview__add_stylesheets"
               ];
-              defaultMode = "acceptEdits";
+              defaultMode = "auto";
               deny = [
                 "Bash(git -C:*)"
               ];


### PR DESCRIPTION
## 目的

claude-code をより快適に使えるように、デフォルトモードを `auto` に変更し、よく利用するコマンド・ドメインの権限を追加する。
合わせて nishiyamanomacbook-pro のメールアドレスを新ドメインに更新する。

## 変更概要

- `claude-code` の `defaultMode` を `acceptEdits` から `auto` に変更
- nix 系コマンドの権限を追加 (`nix hash`, `nix-prefetch-github`, `nix-prefetch-url`, `nix search`)
- WebFetch の許可ドメインに `graphite.com`, `registry.npmjs.org` を追加
- nishiyamanomacbook-pro のメールアドレスを `ascendlogi.co.jp` ドメインに更新
- `defaultMode = auto` がグローバルデフォルトになったため、nishiyamanomacbook-pro での上書き設定を削除

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)