### PR TITLE
statusline に reasoning effort のレベルを表示

### DIFF
--- a/.ai-agent/tasks/20260426-add-effort-to-statusline/README.md
+++ b/.ai-agent/tasks/20260426-add-effort-to-statusline/README.md
@@ -1,0 +1,45 @@
+# add-effort-to-statusline
+
+## 目的・ゴール
+
+`nix/programs/claude-code/statusline.sh` に Claude Code の reasoning effort（`/effort` で切り替え可能）を表示する。
+
+## 背景
+
+Claude Code の status line script に渡される JSON には `effort.level` フィールドが含まれており、現在の reasoning effort を取得できる（公式ドキュメント: https://code.claude.com/docs/en/statusline）。
+
+- `effort.level`: `low` / `medium` / `high` / `xhigh` / `max`
+- モデルが effort パラメータをサポートしていない場合は、フィールド自体が JSON に含まれない
+- thinking 表示は今回不要（要件外）
+
+過去のタスク `20260321-improve-statusline-layout` で「effort」表示を計画していたが未実装。当時は `output_style.name` を effort 代わりに表示する案だったが、現在は公式の `effort.level` フィールドが使えるためそちらを採用する。
+
+## 実装方針
+
+1. `statusline.sh` で `.effort.level` を jq で抽出（フィールドが無い場合は空）
+2. 値が存在する場合のみ表示（モデル非対応時はサイレントに省略）
+3. 表示位置は line2 の末尾（`ctx | 5h | 7d | model | effort`）
+4. レベルごとに色分け:
+   - `low`: GREEN
+   - `medium`: GREEN
+   - `high`: YELLOW
+   - `xhigh`: YELLOW
+   - `max`: RED
+5. プレフィックスは付けず、レベル値のみを表示（例: `high`, `max`）
+
+## 完了条件
+
+- [x] `effort.level` を JSON から取得し、値が存在する場合のみ status line に表示される
+- [x] 値が無い場合（フィールド absent）は status line から省略される
+- [x] レベルごとに色分けされる
+- [x] 既存の dir / branch / ctx / 5h / 7d / model 表示が壊れていない
+- [x] pre-commit hooks（shellcheck / shfmt / prettier）が通る
+
+## 作業ログ
+
+- 2026-04-26: タスク開始
+- 2026-04-26: `statusline.sh` に `effort.level` 取得処理を追加
+- 2026-04-26: サンプル JSON で動作確認（effort あり/なし、low/high/max の各色）
+- 2026-04-26: ユーザー要望で表示位置を line2 末尾に変更、`effort:` プレフィックスを除去
+- 2026-04-26: `prek run` で shellcheck / shfmt / prettier 全 pass を確認
+  - 注: `devenv shell lint-all` は upstream nixpkgs の prek patch が当たらず devenv shell 自体が起動できない環境問題があり、`prek run --files` で代替確認

--- a/nix/programs/claude-code/statusline.sh
+++ b/nix/programs/claude-code/statusline.sh
@@ -3,6 +3,7 @@ input=$(cat)
 
 current_dir=$(echo "$input" | jq -r '.workspace.current_dir')
 model=$(echo "$input" | jq -r '.model.display_name')
+effort=$(echo "$input" | jq -r '.effort.level // empty')
 used_percentage=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
 rate_5h=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // 0' | cut -d. -f1)
 rate_5h_resets=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // 0' | cut -d. -f1)
@@ -32,6 +33,18 @@ if [ -n "$branch" ]; then
 	else
 		branch_part="${branch}"
 	fi
+fi
+
+# Effort level
+effort_part=""
+if [ -n "$effort" ]; then
+	case "$effort" in
+	low | medium) effort_color="$GREEN" ;;
+	high | xhigh) effort_color="$YELLOW" ;;
+	max) effort_color="$RED" ;;
+	*) effort_color="$GREEN" ;;
+	esac
+	effort_part="${effort_color}${effort}${RESET}"
 fi
 
 # Context usage
@@ -113,9 +126,9 @@ if [ -n "$branch_part" ]; then
 	line1="$line1|$branch_part"
 fi
 
-# Line 2: ctx|5h|7d|model|style
+# Line 2: ctx|5h|7d|model|effort
 line2=""
-for p in "$ctx_part" "$rate5h_part" "$rate7d_part" "$model_part"; do
+for p in "$ctx_part" "$rate5h_part" "$rate7d_part" "$model_part" "$effort_part"; do
 	if [ -n "$p" ]; then
 		if [ -n "$line2" ]; then
 			line2="$line2|$p"


### PR DESCRIPTION
## 目的

`/effort` で切り替え可能な reasoning effort レベルが status line から見えないため、現在のセッション設定が分かりづらかった。Claude Code の status line script に渡される JSON には `effort.level` フィールドが含まれているので、これを表示することで一目で確認できるようにする。

## 変更概要

- `nix/programs/claude-code/statusline.sh` で `.effort.level` を jq で抽出
- 値が存在する場合のみ line2 末尾（モデル名の後ろ）に表示
- レベルごとに色分け
  - `low` / `medium`: GREEN
  - `high` / `xhigh`: YELLOW
  - `max`: RED
- effort 非対応モデルではフィールドが absent となるため、その場合は表示を省略
- プレフィックスは付けず、レベル値のみを表示

## 動作確認

サンプル JSON で動作を確認:

- effort=high: `ctx:30%|5h:25%|7d:10%|Opus 4.7|high` (high が黄)
- effort=max: `ctx:30%|5h:25%|7d:10%|Opus 4.7|max` (max が赤)
- effort=low: `ctx:5%|5h:5%|7d:1%|Haiku 4.5|low` (low が緑)
- effort 無し: `ctx:30%|5h:25%|7d:10%|Sonnet 4.6` (省略)

`prek run` で shellcheck / shfmt / prettier すべて pass。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)