### PR TITLE
ロックファイル更新と agent-coach スキル追加

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777086106,
-        "narHash": "sha256-hlNpIN18pw3xo34Lsrp6vAMUPn0aB/zFBqL0QXI1Pmk=",
+        "lastModified": 1777151655,
+        "narHash": "sha256-Th3a5OZyEy4kCoyLfefnt+2dwRIrFQqYgMsayF9qzFw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5826802354a74af18540aef0b01bc1320f82cc17",
+        "rev": "6f59831b23d03bbf4fbd13ad167ae25da294cc14",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     "mizunashi-mana-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1777136572,
-        "narHash": "sha256-tO8AwSnlk0ovA6wYxKzS1xcJ7nDjyYDYYbfu/Zg0ss8=",
+        "lastModified": 1777192152,
+        "narHash": "sha256-OGTYeoaJfEUx58LUR/D5w/6iWoCPRIQ8Vas+1pa3fXY=",
         "owner": "mizunashi-mana",
         "repo": "agent-skills",
-        "rev": "b6936c944487a402082e47f9abe272a166a41b94",
+        "rev": "75e32d179ced4521289b1f23b79904241b6d8101",
         "type": "github"
       },
       "original": {
@@ -180,11 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777086133,
-        "narHash": "sha256-tsVUcRrip2UQrTWvFzyhq10fVH3DswSXsWEyji6ErWA=",
+        "lastModified": 1777174695,
+        "narHash": "sha256-St7G9yRQJeVXxiAtozl/h2kA7cnYIwl4OL1gOmJmdjI=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "261bbbfd0be8768a33e5c4a95d77e29b5a7898b4",
+        "rev": "10566729d20763828a653be840e3eef17049aa25",
         "type": "github"
       },
       "original": {

--- a/nix/programs/agent-skills-mizunashi-mana/default.nix
+++ b/nix/programs/agent-skills-mizunashi-mana/default.nix
@@ -7,6 +7,11 @@
   homeManagerImports = [
     {
       programs.agent-skills = {
+        sources.mizunashi-mana-agent-coach = {
+          path = inputs.mizunashi-mana-skills;
+          subdir = "plugins/agent-coach/skills";
+          filter.maxDepth = 1;
+        };
         sources.mizunashi-mana-autodev = {
           path = inputs.mizunashi-mana-skills;
           subdir = "plugins/autodev/skills";
@@ -19,6 +24,7 @@
         };
         skills = {
           enable = [
+            "agent-coach"
             "autodev-init"
             "merge-dependabot-bump-pr"
           ];


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

flake 入力を最新の lockfile に追従させるための定期更新と、その更新に伴って `mizunashi-mana/agent-skills` 側で利用可能になった `agent-coach` スキルの取り込み。

`agent-coach` は Claude Code の transcript を分析してプロンプトやスキル定義の改善提案を行うスキル。

## 変更概要

- `flake.lock` 更新
  - `home-manager`: `5826802` → `6f59831`
  - `mizunashi-mana-skills`: `b6936c9` → `75e32d1`
  - `nix-vscode-extensions`: `261bbbf` → `1056672`
- `nix/programs/agent-skills-mizunashi-mana/default.nix` に `agent-coach` ソースを追加し `skills.enable` に登録

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)