### PR TITLE
chore: Claude Code 設定の追加と gitignore 更新

### DIFF
--- a/nix/programs/claude-code/default.nix
+++ b/nix/programs/claude-code/default.nix
@@ -18,9 +18,11 @@
               CLAUDE_CODE_AUTO_CONNECT_IDE = "0";
               CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "1";
               CLAUDE_CODE_ENABLE_TELEMETRY = "1";
+              CLAUDE_CODE_ENABLE_AWAY_SUMMARY = "0";
               CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
               CLAUDE_CODE_HIDE_ACCOUNT_INFO = "1";
               CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL = "1";
+              CLAUDE_CODE_NO_FLICKER = "1";
               DISABLE_AUTOUPDATER = "1";
               DISABLE_INSTALLATION_CHECKS = "1";
               OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317";
@@ -28,7 +30,6 @@
               OTEL_LOGS_EXPORTER = "otlp";
               OTEL_METRICS_EXPORTER = "otlp";
             };
-            awaySummaryEnabled = false;
             hooks = {
               Notification = [
                 {

--- a/nix/programs/git/conf.d/global.gitignore
+++ b/nix/programs/git/conf.d/global.gitignore
@@ -9,6 +9,8 @@
 
 # claude-code
 .claude/*.local.json
+.claude/scheduled_tasks.lock
+.claude/scheduled_tasks.json
 CLAUDE.local.md
 
 # direnv


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

Claude Code の最近の機能・挙動変更に追従し、設定方法の変更とちらつき抑制を反映する。あわせてスケジュールタスク機能で生成されるローカルファイルが誤ってコミットされないよう gitignore を更新する。

## 変更概要

- `awaySummaryEnabled = false;` 設定を環境変数 `CLAUDE_CODE_ENABLE_AWAY_SUMMARY=0` に移行
- ターミナルのちらつき抑制のため環境変数 `CLAUDE_CODE_NO_FLICKER=1` を追加
- グローバル gitignore に `.claude/scheduled_tasks.lock` と `.claude/scheduled_tasks.json` を追加

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)