### PR TITLE
chore: mizunashi-mana-skills を最新化し agent-coach の split skill に追従

### DIFF
--- a/.ai-agent/structure.md
+++ b/.ai-agent/structure.md
@@ -94,7 +94,7 @@ dotfiles/
 
 - `agent-skills/`: agent-skills-nix 本体の有効化
 - `agent-skills-anthropic/`: anthropic の公式スキル群（`skill-creator` など）
-- `agent-skills-mizunashi-mana/`: mizunashi-mana 製スキル群（`autodev-init`、`merge-dependabot-bump-pr`）
+- `agent-skills-mizunashi-mana/`: mizunashi-mana 製スキル群（`autodev-init`、`merge-dependabot-bump-pr`、agent-coach プラグイン由来の `detect-context-rot` / `detect-missed-skill-triggers` / `detect-rework-and-violations` / `detect-token-hotspots` / `recommend-bash-allowlist`）
 
 ### `nix/home-manager/`
 

--- a/.ai-agent/tasks/20260506-update-mizunashi-agent-skills/README.md
+++ b/.ai-agent/tasks/20260506-update-mizunashi-agent-skills/README.md
@@ -37,7 +37,7 @@ agent-coach umbrella スキル廃止に伴う設定変更に追従する。
       5 つの split skill が enable されている
 - [x] `.ai-agent/structure.md` の記述が新構成と一致
 - [x] lint チェック (prek) が成功 + darwin host build が成功
-- [ ] PR 作成
+- [x] PR 作成: https://github.com/mizunashi-mana/dotfiles/pull/267
 
 ## 作業ログ
 

--- a/.ai-agent/tasks/20260506-update-mizunashi-agent-skills/README.md
+++ b/.ai-agent/tasks/20260506-update-mizunashi-agent-skills/README.md
@@ -1,0 +1,55 @@
+# mizunashi-agent-skills を最新にアップデート
+
+## 目的・ゴール
+
+`flake.lock` 内の `mizunashi-mana-skills` を最新コミットに更新し、
+agent-coach umbrella スキル廃止に伴う設定変更に追従する。
+
+## 背景
+
+- 現在 pin されている revision: `ec133806094c2a306d2fdbc6e96eb228e909b4dc` (2026-04-27)
+- 最新 revision: `d5d4c1bec93eadc68dcb1615375365d86192458e`
+- 差分: 20 commits
+
+主要な変更点:
+
+- **agent-coach umbrella スキル削除** (PR #14, commit `73d6c43`)
+  以下 5 つの split skill に置き換え:
+  - `detect-context-rot`
+  - `detect-token-hotspots`
+  - `detect-rework-and-violations`
+  - `detect-missed-skill-triggers`
+  - `recommend-bash-allowlist`
+- autodev / merge-dependabot-bump-pr プラグインに機能差分なし
+
+## 実装方針
+
+1. `nix flake update mizunashi-mana-skills` で `flake.lock` を更新
+2. `nix/programs/agent-skills-mizunashi-mana/default.nix` の `enable` リストから
+   `"agent-coach"` を削除し、5 つの split skill 全てを有効化する
+3. `.ai-agent/structure.md` の `agent-skills-mizunashi-mana/` 説明文を新構成に追従
+4. `devenv shell lint-all` で全ホスト構成が build できることを確認
+
+## 完了条件
+
+- [x] `flake.lock` の `mizunashi-mana-skills` が最新 revision を指す
+- [x] `agent-skills-mizunashi-mana/default.nix` から `"agent-coach"` が消え、
+      5 つの split skill が enable されている
+- [x] `.ai-agent/structure.md` の記述が新構成と一致
+- [x] lint チェック (prek) が成功 + darwin host build が成功
+- [ ] PR 作成
+
+## 作業ログ
+
+- 2026-05-06: タスク開始。flake.lock 更新と split skill への移行が必要なことを確認。
+- 2026-05-06: `nix flake update mizunashi-mana-skills` で revision を `d5d4c1b` に更新。
+- 2026-05-06: `agent-skills-mizunashi-mana/default.nix` の `enable` リストを
+  `agent-coach` umbrella の代わりに 5 つの split skill (alphabetical) に置換。
+- 2026-05-06: `structure.md` の skill 列挙を新構成に合わせて更新。
+- 2026-05-06: 動作確認:
+  - `nix flake check --no-build`: all checks passed
+  - `nix build .#darwinConfigurations.{air,pro}.system`: 成功
+    - bundle 内に 7 skill (autodev-init / detect-\* x4 / merge-dependabot-bump-pr / recommend-bash-allowlist) + skill-creator が出力されることを確認
+  - Linux ホスト build は platform mismatch (master でも同様) のためスキップ
+  - `prek run`: nixfmt / prettier 含め変更ファイル全て Passed
+  - `devenv shell lint-all` は devenv-nixpkgs のパッチ失敗で実行不可（環境側の問題で本変更とは無関係）

--- a/flake.lock
+++ b/flake.lock
@@ -140,11 +140,11 @@
     "mizunashi-mana-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1777253388,
-        "narHash": "sha256-peMFPa1h6nkNUV94lWvLjx9mahGuwBB9sy0dPImBsig=",
+        "lastModified": 1777998931,
+        "narHash": "sha256-QwJmUz8uGccIYwNgj8E/sxz57ZIIDXj7BNOPtckjAak=",
         "owner": "mizunashi-mana",
         "repo": "agent-skills",
-        "rev": "ec133806094c2a306d2fdbc6e96eb228e909b4dc",
+        "rev": "d5d4c1bec93eadc68dcb1615375365d86192458e",
         "type": "github"
       },
       "original": {

--- a/nix/programs/agent-skills-mizunashi-mana/default.nix
+++ b/nix/programs/agent-skills-mizunashi-mana/default.nix
@@ -24,9 +24,13 @@
         };
         skills = {
           enable = [
-            "agent-coach"
             "autodev-init"
+            "detect-context-rot"
+            "detect-missed-skill-triggers"
+            "detect-rework-and-violations"
+            "detect-token-hotspots"
             "merge-dependabot-bump-pr"
+            "recommend-bash-allowlist"
           ];
         };
       };


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

`flake.lock` 内の `mizunashi-mana-skills` を最新コミットに更新し、
agent-coach umbrella スキル廃止に伴う設定変更に追従する。

## 変更概要

- `flake.lock`: `mizunashi-mana-skills` を `ec13380` (2026-04-27) → `d5d4c1b` (2026-05-05) に更新
- `nix/programs/agent-skills-mizunashi-mana/default.nix`: `enable` リストから `agent-coach` を削除し、5 つの split skill を追加
  - `detect-context-rot`
  - `detect-missed-skill-triggers`
  - `detect-rework-and-violations`
  - `detect-token-hotspots`
  - `recommend-bash-allowlist`
- `.ai-agent/structure.md`: `agent-skills-mizunashi-mana/` の説明を新構成に合わせて更新
- `.ai-agent/tasks/20260506-update-mizunashi-agent-skills/`: タスク管理ドキュメント追加

## 動作確認

- `nix flake check --no-build`: all checks passed
- `nix build .#darwinConfigurations.{nishiyamanomacbook-air,nishiyamanomacbook-pro}.system`: 成功
  - bundle 内に 7 skill (autodev-init / detect-\* x4 / merge-dependabot-bump-pr / recommend-bash-allowlist) + skill-creator が出力されることを確認
- `prek run`: nixfmt / prettier 全て Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)