### PR TITLE
feat: fish の対話シェルに devenv hook を追加

### DIFF
--- a/nix/programs/fish/init.fish
+++ b/nix/programs/fish/init.fish
@@ -12,3 +12,8 @@ else if test -d $HOME/.linuxbrew
 else if test -d /home/linuxbrew/.linuxbrew
     eval (/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 end
+
+# devenv hook
+if status is-interactive
+    devenv hook fish | source
+end


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

fish 起動時にカレントディレクトリの devenv プロジェクトを自動でアクティベートしたいため、`devenv hook fish` を fish の対話シェル初期化に組み込む。

## 変更概要

- `nix/programs/fish/init.fish` に `devenv hook fish | source` を追加
- `status is-interactive` ガードを入れて、非対話シェルでは hook 取得コストが発生しないようにした
