### PR TITLE
feat: antigravity を antigravity-ide にリネーム

### DIFF
--- a/.ai-agent/tasks/20260607-rename-antigravity-to-antigravity-ide/README.md
+++ b/.ai-agent/tasks/20260607-rename-antigravity-to-antigravity-ide/README.md
@@ -25,7 +25,7 @@ Antigravity の Nix モジュール・Homebrew cask・dock アプリ参照を、
 - [x] dock の persistent-apps が `Antigravity IDE.app` を参照している
 - [x] モジュールディレクトリ / import パスがリネームされている
 - [x] `devenv shell lint-all` が通る
-- [ ] PR を作成（`/autodev-create-pr`）
+- [x] PR を作成（`/autodev-create-pr`） → https://github.com/mizunashi-mana/dotfiles/pull/282
 
 ## 作業ログ
 

--- a/.ai-agent/tasks/20260607-rename-antigravity-to-antigravity-ide/README.md
+++ b/.ai-agent/tasks/20260607-rename-antigravity-to-antigravity-ide/README.md
@@ -1,29 +1,44 @@
-# antigravity を antigravity-ide にリネーム
+# antigravity を antigravity-ide にリネーム + gemini-cli を antigravity-cli へ切替
 
 ## 目的・ゴール
 
-Antigravity の Nix モジュール・Homebrew cask・dock アプリ参照を、実際の cask 名 `antigravity-ide` と
-インストールされるアプリ名 `Antigravity IDE.app` に合わせて修正する。
+1. Antigravity IDE の Nix モジュール・Homebrew cask・dock アプリ参照を、実際の cask 名 `antigravity-ide` と
+   インストールされるアプリ名 `Antigravity IDE.app` に合わせて修正する。
+2. Gemini CLI モジュールを Antigravity CLI に切り替える（インストールするツール自体を変更）。
 
 ### 背景
 
 - Homebrew cask の正式名は `antigravity-ide`（Google Antigravity IDE）。現状の設定では `antigravity` を指定している。
 - cask がインストールするアプリは `Antigravity IDE.app` だが、dock の persistent-apps は `/Applications/Antigravity.app` を参照しており不整合。
+- home-manager 上流で `programs.gemini-cli` は `programs.antigravity-cli` にリネームされ、`gemini-cli.nix` モジュールは廃止された。
+  この新オプションは更新後の home-manager にのみ存在するため、flake.lock の更新が必要。
+- `antigravity-cli` パッケージ（nixpkgs, 1.0.3）のバイナリ名は `agy`。agent-skills-nix には `targets.antigravity` が存在する。
 
 ## 実装方針
+
+### Antigravity IDE（cask / dock）
 
 1. モジュールディレクトリ `nix/programs/google-antigravity/` を `nix/programs/antigravity-ide/` にリネーム。
 2. `nix/programs/antigravity-ide/default.nix` の cask を `antigravity` → `antigravity-ide` に変更。
 3. `nix/programs/default-darwin.nix` の import パスを `./google-antigravity` → `./antigravity-ide` に変更。
 4. `nix/nix-darwin/system/default.nix` の dock アプリ参照を
    `/Applications/Antigravity.app` → `/Applications/Antigravity IDE.app` に変更。
-5. `.ai-agent/structure.md` などにモジュール名の記載があれば追従（要確認）。
+
+### Antigravity CLI（gemini-cli からの切替）
+
+5. モジュールディレクトリ `nix/programs/gemini-cli/` を `nix/programs/antigravity-cli/` にリネーム。
+6. モジュール内容を `programs.antigravity-cli`（package = `antigravity-cli`）・`targets.antigravity.enable` に変更。
+7. import パス（`default-common.nix` / `devcontainer-claude/default.nix`）を `antigravity-cli` に変更。
+8. `claude-code/default.nix` の権限を `Bash(gemini:*)` → `Bash(agy:*)` に変更。
+9. `flake.lock` を更新（home-manager に `programs.antigravity-cli` オプションを取り込むため）。
 
 ## 完了条件
 
 - [x] cask が `antigravity-ide` に変更されている
 - [x] dock の persistent-apps が `Antigravity IDE.app` を参照している
-- [x] モジュールディレクトリ / import パスがリネームされている
+- [x] antigravity-ide モジュールディレクトリ / import パスがリネームされている
+- [x] gemini-cli モジュールが antigravity-cli に切り替わっている（package = `antigravity-cli`、`Bash(agy:*)`）
+- [x] flake.lock を更新し home-manager の `programs.antigravity-cli` を解決できる
 - [x] `devenv shell lint-all` が通る
 - [x] PR を作成（`/autodev-create-pr`） → https://github.com/mizunashi-mana/dotfiles/pull/282
 
@@ -37,3 +52,11 @@ Antigravity の Nix モジュール・Homebrew cask・dock アプリ参照を、
   - import パス `./google-antigravity` → `./antigravity-ide`
   - dock アプリ `/Applications/Antigravity.app` → `/Applications/Antigravity IDE.app`
   - `devenv shell lint-all` で `all checks passed!` を確認。
+- 2026-06-07: PR #282 作成後、追加要望で gemini-cli → antigravity-cli の切替を同一 PR に追加。
+  - home-manager 上流で `programs.gemini-cli` が `programs.antigravity-cli` に改名済みであることを確認（`gemini-cli.nix` は廃止）。
+    コミット済み flake.lock の home-manager（rev `7d8127d`）では新オプションが存在せず評価エラーになるため、`nix flake update` を実施。
+  - `nix/programs/gemini-cli/` → `nix/programs/antigravity-cli/`（`git mv`）、package を `antigravity-cli`（bin: `agy`）に指定。
+  - agent-skills のターゲットを `gemini` → `antigravity` に変更。
+  - import パス（`default-common.nix` / `devcontainer-claude`）と `claude-code` の権限（`Bash(agy:*)`）を更新。
+  - flake.lock は全 input が更新された（home-manager / nixpkgs / agent-skills 他）。ユーザー指示によりそのまま保持。
+  - darwin / home 両構成の評価成功・`devenv shell lint-all` で `all checks passed!` を再確認。

--- a/.ai-agent/tasks/20260607-rename-antigravity-to-antigravity-ide/README.md
+++ b/.ai-agent/tasks/20260607-rename-antigravity-to-antigravity-ide/README.md
@@ -1,0 +1,39 @@
+# antigravity を antigravity-ide にリネーム
+
+## 目的・ゴール
+
+Antigravity の Nix モジュール・Homebrew cask・dock アプリ参照を、実際の cask 名 `antigravity-ide` と
+インストールされるアプリ名 `Antigravity IDE.app` に合わせて修正する。
+
+### 背景
+
+- Homebrew cask の正式名は `antigravity-ide`（Google Antigravity IDE）。現状の設定では `antigravity` を指定している。
+- cask がインストールするアプリは `Antigravity IDE.app` だが、dock の persistent-apps は `/Applications/Antigravity.app` を参照しており不整合。
+
+## 実装方針
+
+1. モジュールディレクトリ `nix/programs/google-antigravity/` を `nix/programs/antigravity-ide/` にリネーム。
+2. `nix/programs/antigravity-ide/default.nix` の cask を `antigravity` → `antigravity-ide` に変更。
+3. `nix/programs/default-darwin.nix` の import パスを `./google-antigravity` → `./antigravity-ide` に変更。
+4. `nix/nix-darwin/system/default.nix` の dock アプリ参照を
+   `/Applications/Antigravity.app` → `/Applications/Antigravity IDE.app` に変更。
+5. `.ai-agent/structure.md` などにモジュール名の記載があれば追従（要確認）。
+
+## 完了条件
+
+- [x] cask が `antigravity-ide` に変更されている
+- [x] dock の persistent-apps が `Antigravity IDE.app` を参照している
+- [x] モジュールディレクトリ / import パスがリネームされている
+- [x] `devenv shell lint-all` が通る
+- [ ] PR を作成（`/autodev-create-pr`）
+
+## 作業ログ
+
+- 2026-06-07: タスク開始。トリアージの結果そのまま start-new-task で続行。
+  `brew info --cask antigravity-ide` で正式 cask 名 `antigravity-ide` とアプリ名 `Antigravity IDE.app` を確認。
+- 2026-06-07: 実装完了。以下4点を変更。
+  - `nix/programs/google-antigravity/` → `nix/programs/antigravity-ide/`（`git mv`）
+  - cask `antigravity` → `antigravity-ide`
+  - import パス `./google-antigravity` → `./antigravity-ide`
+  - dock アプリ `/Applications/Antigravity.app` → `/Applications/Antigravity IDE.app`
+  - `devenv shell lint-all` で `all checks passed!` を確認。

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1779899208,
-        "narHash": "sha256-2LN9997pFL+b1FWA0375mm6/THvIq7okQy+Mc49/Uq0=",
+        "lastModified": 1780613187,
+        "narHash": "sha256-Vo9RgXBdWJ537smbCGIyCdmhqp35z5G6kH1mUhnn5Ag=",
         "owner": "1Password",
         "repo": "shell-plugins",
-        "rev": "17d290441359204fc6df8de252698f52cbd87047",
+        "rev": "af9327a7375e910219fc910d2c7db0cf54f1f5b0",
         "type": "github"
       },
       "original": {
@@ -31,11 +31,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779957311,
-        "narHash": "sha256-ay1wGiKQIGIcFpSxlutpoAlsPVerbVhDUXtmaDVLz+o=",
+        "lastModified": 1780430501,
+        "narHash": "sha256-nNjp1HJGnscx1lC/bagz4FfuUIPsq2lgkd93R3JBhr8=",
         "owner": "Kyure-A",
         "repo": "agent-skills-nix",
-        "rev": "df7a6e0fa87655cf28369781232d153c1c7b55ca",
+        "rev": "ba550ebf77004b8a1f865528fc9a1d7e22628501",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780109992,
-        "narHash": "sha256-qzmk1JsVr3Umi4k9cx5KCLxPSWQpd6NeKCXXSr4bYoY=",
+        "lastModified": 1780709764,
+        "narHash": "sha256-TmYUn7Gr92j2qsrBiNdxxyboeUgsbCQ9xEn+aBsOcxQ=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "66c8b1714f2d45ce71de002baa89f8652483f245",
+        "rev": "621404fd3264455b1b451e90e90566c4b67c2fb4",
         "type": "github"
       },
       "original": {
@@ -150,11 +150,11 @@
         "uv2nix": "uv2nix_2"
       },
       "locked": {
-        "lastModified": 1780223957,
-        "narHash": "sha256-4/+h2z29mzZCuZSNiJ59bn2NnU8R+nO4a6gHw9yXhoY=",
+        "lastModified": 1780757504,
+        "narHash": "sha256-5oQ3j8M7tNLd6GXkhOvcgX063u/LSeMse3PumhFtTiI=",
         "owner": "NousResearch",
         "repo": "hermes-agent",
-        "rev": "1fc7bdc5e64e052bc61d3ddb9e6f96cf6c7461dc",
+        "rev": "1c2189839d0bb57c8e0ac0aa44dd53fef73665b2",
         "type": "github"
       },
       "original": {
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780099287,
-        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
+        "lastModified": 1780679734,
+        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
+        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
         "type": "github"
       },
       "original": {
@@ -226,11 +226,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780201196,
-        "narHash": "sha256-uPuFWteQmf/5yMe0o79EHMZk8yRzai+qENu2zdruYs4=",
+        "lastModified": 1780718391,
+        "narHash": "sha256-hQOS9bTTzVXQNYaW4bi2EyXN8jqDe7ge07xPPbvUMuA=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "6db47539132df7843e36586a0e66edc71a61737f",
+        "rev": "e2ccd7477aa7174e34bd32c135dc470a3f822a82",
         "type": "github"
       },
       "original": {
@@ -241,11 +241,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780030872,
-        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
+        "lastModified": 1780365719,
+        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
+        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
         "type": "github"
       },
       "original": {

--- a/nix/hosts/devcontainer-claude/default.nix
+++ b/nix/hosts/devcontainer-claude/default.nix
@@ -31,7 +31,7 @@ let
   extra-programs = [
     (import "${nix-root-dir}/programs/gh" { inherit packages; })
     (import "${nix-root-dir}/programs/claude-code" { inherit packages; })
-    (import "${nix-root-dir}/programs/gemini-cli" { inherit packages; })
+    (import "${nix-root-dir}/programs/antigravity-cli" { inherit packages; })
     (import "${nix-root-dir}/programs/neovim" { inherit packages; })
     (import "${nix-root-dir}/programs/ripgrep" { inherit packages; })
     (import "${nix-root-dir}/programs/docker-client" { inherit packages; })

--- a/nix/nix-darwin/system/default.nix
+++ b/nix/nix-darwin/system/default.nix
@@ -47,7 +47,7 @@
             app = "/Applications/Claude.app";
           }
           {
-            app = "/Applications/Antigravity.app";
+            app = "/Applications/Antigravity IDE.app";
           }
           {
             app = "${packages.pkgs.dbeaver-bin}/Applications/dbeaver.app";

--- a/nix/programs/antigravity-cli/default.nix
+++ b/nix/programs/antigravity-cli/default.nix
@@ -5,12 +5,13 @@
 {
   homeManagerImports = [
     {
-      programs.gemini-cli = {
+      programs.antigravity-cli = {
         enable = true;
+        package = packages.pkgs.antigravity-cli;
       };
 
       programs.agent-skills = {
-        targets.gemini.enable = true;
+        targets.antigravity.enable = true;
       };
     }
   ];

--- a/nix/programs/antigravity-ide/default.nix
+++ b/nix/programs/antigravity-ide/default.nix
@@ -5,7 +5,7 @@
   nixDarwinModules = [
     {
       homebrew.casks = [
-        "antigravity"
+        "antigravity-ide"
       ];
     }
   ];

--- a/nix/programs/claude-code/default.nix
+++ b/nix/programs/claude-code/default.nix
@@ -111,7 +111,7 @@
                 "Bash(find:*)"
                 "Bash(file:*)"
                 "Bash(for:*)"
-                "Bash(gemini:*)"
+                "Bash(agy:*)"
                 "Bash(gh cache list:*)"
                 "Bash(gh issue list:*)"
                 "Bash(gh issue view:*)"

--- a/nix/programs/default-common.nix
+++ b/nix/programs/default-common.nix
@@ -31,7 +31,7 @@ let
     (import ./claude-code { inherit packages; })
     (import ./cc-voice-reporter { inherit packages; })
     (import ./docker-client { inherit packages; })
-    (import ./gemini-cli { inherit packages; })
+    (import ./antigravity-cli { inherit packages; })
     (import ./codex { inherit packages; })
     (import ./agent-skills { inherit packages inputs; })
     (import ./agent-skills-anthropic { inherit packages inputs; })

--- a/nix/programs/default-darwin.nix
+++ b/nix/programs/default-darwin.nix
@@ -33,7 +33,7 @@ let
     (import ./vagrant { inherit packages; })
     (import ./aerospace { inherit packages; })
     (import ./vscode { inherit packages; })
-    (import ./google-antigravity { inherit packages; })
+    (import ./antigravity-ide { inherit packages; })
     (import ./google-chrome { inherit packages; })
     (import ./aquaskk { inherit packages; })
     (import ./skimpdf { inherit packages; })


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

Google の AI コーディングツール周りの設定を実態に合わせて整理する。

1. **Antigravity IDE**: Homebrew cask 指定が実態と乖離していた。正式な cask 名は `antigravity-ide`（Google Antigravity IDE）で、インストールされるアプリ名は `Antigravity IDE.app` だが、設定では cask `antigravity` / dock `Antigravity.app` を参照していた。
2. **Antigravity CLI**: home-manager 上流で `programs.gemini-cli` が `programs.antigravity-cli` にリネームされた（`gemini-cli.nix` は廃止）。これに追従し、インストールするツールも Gemini CLI から Antigravity CLI へ切り替える。

## 変更概要

### Antigravity IDE（cask / dock）

- モジュールディレクトリ `nix/programs/google-antigravity/` → `nix/programs/antigravity-ide/`
- Homebrew cask `antigravity` → `antigravity-ide`
- import パス `./google-antigravity` → `./antigravity-ide`
- dock の persistent-apps `/Applications/Antigravity.app` → `/Applications/Antigravity IDE.app`

### Antigravity CLI（gemini-cli からの切替）

- モジュールディレクトリ `nix/programs/gemini-cli/` → `nix/programs/antigravity-cli/`
- `programs.antigravity-cli`（`package = antigravity-cli`、bin: `agy`）/ `targets.antigravity.enable` に変更
- import パス（`default-common.nix` / `devcontainer-claude`）を `antigravity-cli` に変更
- claude-code 権限 `Bash(gemini:*)` → `Bash(agy:*)`
- `flake.lock` を更新（home-manager の `programs.antigravity-cli` オプションを取り込むため。home-manager / nixpkgs / agent-skills 他の input が更新される）

## 確認

- darwin / home 両構成の評価成功
- `devenv shell lint-all` で `all checks passed!`
