### PR TITLE
fix: dependabot.yml の cooldown 設定を各 updates エントリへ移動

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,15 @@ updates:
       - "/.github/actions/*"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
   - package-ecosystem: "npm"
     directories:
       - "/"
       - "nix/packages/node-pkgs/*/"
     schedule:
       interval: "weekly"
-
-cooldown:
-  default-days: 7
-  semver-major-days: 30
+    cooldown:
+      default-days: 7
+      semver-major-days: 30


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

Dependabot が `.github/dependabot.yml` のパースに失敗していたエラーを解消する。

```
The property '#/' contains additional properties ["cooldown"] outside of the schema when none are allowed
```

`cooldown` をトップレベルに置いていたが、Dependabot のスキーマでは `cooldown` は各 `updates` エントリ配下のオプションであり、トップレベルには置けないため検証に失敗していた。

参考: 失敗した check run https://github.com/mizunashi-mana/dotfiles/runs/78724917205

## 変更概要

- トップレベルの `cooldown` を削除
- `github-actions` / `npm` の各 `updates` エントリ配下に `cooldown` を移動
