### PR TITLE
fix: github-actions の cooldown 設定検証エラーを修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 7
-      semver-major-days: 30
   - package-ecosystem: "npm"
     directories:
       - "/"


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

Dependabot の設定検証で以下のエラーが発生していたため修正する。

```
The property '#/updates/0/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
```

## 変更概要

- `github-actions` エコシステムの `cooldown` から `semver-major-days: 30` を削除
  - `github-actions` では `cooldown.semver-major-days` がサポートされていないため
  - `default-days: 7` は維持
- npm エコシステム側の `cooldown` は対象外（`semver-major-days` をサポートするため変更なし）
